### PR TITLE
Update CallRecorderService.java

### DIFF
--- a/src/com/android/services/callrecorder/CallRecorderService.java
+++ b/src/com/android/services/callrecorder/CallRecorderService.java
@@ -211,7 +211,7 @@ public class CallRecorderService extends Service {
         if (audioFormat == MediaRecorder.OutputFormat.AMR_WB){
             return number + "_" + timestamp + ".amr";
         } else {
-            return number + "_" + timestamp + ".m4a ";
+            return number + "_" + timestamp + ".m4a";
         }
     }
 


### PR DESCRIPTION
Removed space at end of .m4a extension in generateFilename method, that prevented File Manager from recognising the saved file as a media file, and prevented Music from detecting the saved file.
