### PR TITLE
Dialer: Enable Call Recording for Canada

### DIFF
--- a/res/values-mcc515/config.xml
+++ b/res/values-mcc515/config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!--Allow recording for country: Canada-->
+<!--Legal precedent source: http://www.canlii.org/en/bc/bcca/doc/1988/1988canlii3273/1988canlii3273.html -->
+<!--Legal precedent source: http://www.theglobeandmail.com/report-on-business/careers/career-advice/experts/am-i-allowed-to-record-conversations-at-work/article21877154/ -->
+<!--Legal precedent source: http://www.cba.org/CBA/newsletters/priv-2008-2/news.aspx -->
+<!--Legal precedent source: http://blog.privacylawyer.ca/2006/07/can-you-record-telephone-calls-without.html -->
+<!--Legal precedent source: http://www.legaltree.ca/node/908 -->
+<!--Legal precedent source: https://www.priv.gc.ca/resource/fs-fi/02_05_d_14_e.asp -->
+<resources>
+
+</resources>


### PR DESCRIPTION
Call recording is legal in Canada by private citizens as long as one member of the conversation knows that they are being recorded.

Companies have to notify any person calling in that they are recording, but they are still allowed to record.

Here is the case that establishes it, a link to the Canadian government's web page about it, and various news articles and blog posts about it.
